### PR TITLE
Update to latest dai-ui-theme-maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ _See the official [Dai-UI](https://github.com/makerdao/dai-ui) repo for more in-
 1.  **Clone**
 
     ```shell
-    git clone https://github.com/MaximumCrash/maker-portal-sandbox.git
+    git clone https://github.com/makerdao/community-portal.git
     ```
 
 2.  **Install**

--- a/package.json
+++ b/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "community-development-portal",
   "private": true,
-  "description": "A simple starter to get up and developing quickly with Gatsby",
+  "description": "A simple starter to get up and developing quickly with Gatsby + DAI-UI",
   "version": "0.1.0",
-  "author": "Kyle Mathews <mathews.kyle@gmail.com>",
+  "author": "Réjon Taylor-Foster (@Maximum_Crash)",
   "dependencies": {
-    "@makerdao/dai-ui-icons": "^0.0.29",
-    "@makerdao/dai-ui-theme-maker": "^0.0.29",
-    "@makerdao/dai-ui-theme-oasis": "^0.0.35",
+    "@makerdao/dai-ui-icons": "^0.0.38",
+    "@makerdao/dai-ui-theme-maker": "^0.0.38",
     "@mdx-js/mdx": "^1.6.5",
     "@mdx-js/react": "^1.6.5",
     "@theme-ui/sidenav": "^0.3.1",
@@ -49,9 +48,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/gatsbyjs/gatsby-starter-default"
+    "url": "https://github.com/makerdao/community-portal"
   },
   "bugs": {
-    "url": "https://github.com/gatsbyjs/gatsby/issues"
+    "url": "https://github.com/makerdao/community-portal/issues"
   }
 }


### PR DESCRIPTION
### Attention (CC)
@MaximumCrash 

## Summary of changes
Slight edit on the README instructions.
Remove dau-ui-theme-oasis as no longer used
Update to latestest dai-ui-theme-maker with responsive typography added recently by Philip

## Motivation & Context
- Feature: A discussion with Phillip brought to light recent updates to dai-ui, which I thought best to keep abreast of.
- "In the past we had text variants that used document notion (eg: h1, h2), and the variant was used like this `<Text variant="h2" ...`, but we've changed to a more general usage like "largeHeading", "mediumHeading", used like this: `<Text variant="mediumHeading" ...`"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation Update 
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
