### PR TITLE
Structure for develop section of portal

### DIFF
--- a/content/en/develop/content/advanced.mdx
+++ b/content/en/develop/content/advanced.mdx
@@ -1,0 +1,7 @@
+---
+order: 4
+---
+
+# Advanced
+
+Passing in props, setting `sx` values etc. This is where we really get to creating React components properly in mdx.

--- a/content/en/develop/content/basic.mdx
+++ b/content/en/develop/content/basic.mdx
@@ -1,0 +1,8 @@
+---
+order: 2
+---
+
+# Basic
+
+A very basic intro to what a component is, why you might want to use one in your writing (to attract attention etc) 
+and the most basic kinds - buttons, CTAs, images, headers etc.

--- a/content/en/develop/content/frontmatter.mdx
+++ b/content/en/develop/content/frontmatter.mdx
@@ -19,38 +19,44 @@ in the place you want it to.
 title[String] - Display title used for Header,Sidenav, and SEO.  
 title: Frontmatter
 ```
-<CTA warning>
 
-    **The Title Rule**  
+<Box sx={{backgroundColor: 'success', padding: 3, marginBottom: 4}}>
 
-    <Box>
+### The Title Rule 
 
-        This specifies that we read and display the title in the frontmatter first, then the first h1 in the file,
-        then we fall back to the name of the file. The Title Rule applies globally.
+This specifies that we read and display the title in the frontmatter first, then the first h1 in the file,
+then we fall back to the name of the file. The Title Rule applies globally.
 
-    </Box>
+</Box>
 
-</CTA>
+<Box sx={{backgroundColor: 'notice', padding: 3, marginBottom: 4}}>
+
+The "title" attribute is used for the title meta attribute for SEO. The title rule still applies.
+
+</Box>
 
 ## Order
+
+This is a frontmatter attribute unique to this site which we use to define the order in which different pages appear 
+in the sidebar navigation.
 
 ```md:title=order-example.mdx
 order[Integer] - The order in which this file is displayed on the sidenav.
 order: 0
 ```
-<CTA warning>
+<Box sx={{backgroundColor: 'success', padding: 3, marginBottom: 4}}>
 
-    ** Ordering ** 
+### Ordering
 
-    <Box>
+Order in the sidenav is based on lowest number (TOP) to highest (BOTTOM). Files that don't have an order are applied AFTER files that 
+have order in alphabetical order. If this file isn't rendered on the sidenav (ie. Top section files) this won't matter.
 
-        Order in the sidenav is based on lowest number (TOP) to highest (BOTTOM). Files that don't have an order are applied AFTER files that 
-        have order in alphabetical order. If this file isn't rendered on the sidenav (ie. Top section files) this won't matter.
-
-    </Box>
-</CTA>
+</Box>
 
 ## Language Selector 
+
+This is a frontmatter attribute unique to this site which defines whether users will be able to see the different languages available for 
+the particular page they are currently on.
 
 ```md:title=language-example.mdx
 hideLanguageSelector[Boolean] - Language selectors render by default, setting this to true for your page allows you to hide it. 
@@ -59,6 +65,10 @@ hideLanguageSelector: false
 
 ## Header Navigation
 
+The header options are an easy way of adding internal files to the global header. Files specified in header.mdx gets applied AFTER these. 
+Files are organised in the header based on lowest number (LEFT) to highest (RIGHT). "Home" is ALWAYS first, then files with headerOrder, 
+then links in header.mdx.
+
 ```md:title=header-example.mdx
 header[String] -  Whether this File should be rendered in the Header Navigation.
 header: true
@@ -66,28 +76,22 @@ header: true
 headerOrder[Integer] - The order in which this file will be displayed on the header. 
 headerOrder: 0
 ```
-<CTA warning>
-
-    The header options are an easy way of adding internal files to the global header. Files specified in header.mdx gets applied AFTER these. 
-    Files are organised in the header based on lowest number (LEFT) to highest (RIGHT). "Home" is ALWAYS first, then files with headerOrder, 
-    then links in header.mdx.
-
-</CTA>
 
 ## SEO
 
-**NOTE: "title" is used for the title meta attribute. Title rule still applies.**
+So you want your page to rank well, and have a nice image and description when you share it on social media to show your friends 
+the awesome work you've done? We've got you covered.
 
 ```md:title=image-example.mdx
 featuredImage[String] - Image to use when a link is shared (ie. Twitter/Facebook)
 featuredImage: "../images/test.png"
 ```
 
-<CTA warning>
+<Box sx={{backgroundColor: 'warning', padding: 3, marginBottom: 4}}>
 
-    Image must be a path to the images in content/images/
+The "image" attribute **must** be a path to the images in `content/images/`
 
-</CTA>
+</Box>
 
 ```md:title=keywords-example.mdx
 keywords[String] - Comma seperated keywords used for SEO
@@ -99,8 +103,8 @@ description[String] - Description of this page for SEO.
 description: "The most complete guide to writing frontmatter in mdx files that you've ever read."
 ```
 
-<CTA warning>
+<Box sx={{backgroundColor: 'notice', padding: 3, marginBottom: 4}}>
 
-    "description" can ALSO used for the excerpt that gets rendered and indexed for searching articles on the site.
-    
-</CTA>
+The "description" attribute can ALSO be used for the excerpt that gets rendered and indexed for searching articles on the site.
+
+</Box>

--- a/content/en/develop/content/frontmatter.mdx
+++ b/content/en/develop/content/frontmatter.mdx
@@ -1,0 +1,91 @@
+---
+title: Frontmatter
+order: 1
+hideLanguageSelector: true
+keywords: "frontmatter, guide, markdown, help, technical"
+description: "The most complete guide to writing frontmatter in mdx files that you've ever read."
+---
+
+# Frontmatter
+
+Frontmatter is the stuff you put at the very top of your markdown files to control everything from the title, page description, 
+images, and SEO. On this site, we also use it to control what appears in the gloabl header navigation, as well as how the sidebar 
+gets rendered in each section. It's therefore quite important to know how to structure your frontmatter so that your file appears 
+in the place you want it to.
+
+## Title
+
+```md:title=title-example.mdx
+title[String] - Display title used for Header,Sidenav, and SEO.  
+title: Frontmatter
+```
+<CTA warning>
+    **The Title Rule**  
+    <Box>
+        This specifies that we read and display the title in the frontmatter first, then the first h1 in the file,
+        then we fall back to the name of the file. The Title Rule applies globally.
+    </Box>
+</CTA>
+
+## Order
+
+```md:title=order-example.mdx
+order[Integer] - The order in which this file is displayed on the sidenav.
+order: 0
+```
+<CTA warning>
+    ** Ordering **  
+    <Box>
+        Order in the sidenav is based on lowest number (TOP) to highest (BOTTOM). Files that don't have an order are applied AFTER files that 
+        have order in alphabetical order. If this file isn't rendered on the sidenav (ie. Top section files) this won't matter.
+    </Box>
+</CTA>
+
+## Language Selector 
+
+```md:title=language-example.mdx
+hideLanguageSelector[Boolean] - Language selectors render by default, setting this to true for your page allows you to hide it. 
+hideLanguageSelector: false
+```
+
+## Header Navigation
+
+```md:title=header-example.mdx
+header[String] -  Whether this File should be rendered in the Header Navigation.
+header: true
+  
+headerOrder[Integer] - The order in which this file will be displayed on the header. 
+headerOrder: 0
+```
+<CTA warning>
+    The header options are an easy way of adding internal files to the global header. Files specified in header.mdx gets applied AFTER these. 
+    Files are organised in the header based on lowest number (LEFT) to highest (RIGHT). "Home" is ALWAYS first, then files with headerOrder, 
+    then links in header.mdx.
+</CTA>
+
+## SEO
+
+**NOTE: "title" is used for the title meta attribute. Title rule still applies.**
+
+```md:title=image-example.mdx
+featuredImage[String] - Image to use when a link is shared (ie. Twitter/Facebook)
+featuredImage: "../images/test.png"
+```
+
+<CTA warning>
+    Image must be a path to the images in content/images/
+</CTA>
+
+```md:title=keywords-example.mdx
+keywords[String] - Comma seperated keywords used for SEO
+keywords: "cool, sweet, awesome"
+```
+
+```md:title=description-example.mdx
+description[String] - Description of this page for SEO.
+description: "The most complete guide to writing frontmatter in mdx files that you've ever read."
+```
+
+<CTA warning>
+    "description" can ALSO used for the excerpt that gets rendered and indexed for searching articles on the site.
+</CTA>

--- a/content/en/develop/content/frontmatter.mdx
+++ b/content/en/develop/content/frontmatter.mdx
@@ -20,11 +20,16 @@ title[String] - Display title used for Header,Sidenav, and SEO.
 title: Frontmatter
 ```
 <CTA warning>
+
     **The Title Rule**  
+
     <Box>
+
         This specifies that we read and display the title in the frontmatter first, then the first h1 in the file,
         then we fall back to the name of the file. The Title Rule applies globally.
+
     </Box>
+
 </CTA>
 
 ## Order
@@ -34,10 +39,14 @@ order[Integer] - The order in which this file is displayed on the sidenav.
 order: 0
 ```
 <CTA warning>
-    ** Ordering **  
+
+    ** Ordering ** 
+
     <Box>
+
         Order in the sidenav is based on lowest number (TOP) to highest (BOTTOM). Files that don't have an order are applied AFTER files that 
         have order in alphabetical order. If this file isn't rendered on the sidenav (ie. Top section files) this won't matter.
+
     </Box>
 </CTA>
 
@@ -58,9 +67,11 @@ headerOrder[Integer] - The order in which this file will be displayed on the hea
 headerOrder: 0
 ```
 <CTA warning>
+
     The header options are an easy way of adding internal files to the global header. Files specified in header.mdx gets applied AFTER these. 
     Files are organised in the header based on lowest number (LEFT) to highest (RIGHT). "Home" is ALWAYS first, then files with headerOrder, 
     then links in header.mdx.
+
 </CTA>
 
 ## SEO
@@ -73,7 +84,9 @@ featuredImage: "../images/test.png"
 ```
 
 <CTA warning>
+
     Image must be a path to the images in content/images/
+
 </CTA>
 
 ```md:title=keywords-example.mdx
@@ -87,5 +100,7 @@ description: "The most complete guide to writing frontmatter in mdx files that y
 ```
 
 <CTA warning>
+
     "description" can ALSO used for the excerpt that gets rendered and indexed for searching articles on the site.
+    
 </CTA>

--- a/content/en/develop/content/index.mdx
+++ b/content/en/develop/content/index.mdx
@@ -1,0 +1,13 @@
+---
+order: 0
+---
+
+# Crafting Technical Content
+
+This section is not about writing - the Writing Guide in our Learn section will teach you everything 
+you need to know about our style, tone, and other content tricks. This section is all about how to 
+add automagic, ready-made React components to your files so that they really pop. We'll start with the basics: 
+buttons, Calls to Action (CTAs), images, headers etc. and gradually progress to passing your own props to 
+some of the more advanced components this site offers, all while remaining in a familiar markdown file.
+
+Writing markdown which renders responsive React components is a superpower. We hope you'll use it responsibly.

--- a/content/en/develop/content/intermediate.mdx
+++ b/content/en/develop/content/intermediate.mdx
@@ -1,0 +1,8 @@
+---
+order: 3
+---
+
+# Intermediate
+
+Some of the more picky components which require some degree of thought about which order you put things in, 
+a short description of children and how to think about them etc.

--- a/content/en/develop/engineering/index.mdx
+++ b/content/en/develop/engineering/index.mdx
@@ -1,0 +1,25 @@
+---
+order: 0
+---
+
+# Engineering for Communities
+
+This site was not just created to make it easy for content contributors to create their own pages with minimal developer oversight. 
+It's explicitly meant to be easy for engineers to extend. MakerDAO is about building better money, and this requires that the tools 
+we use are openly accessible and can be used without permission. We're taking that a step further here, by making our community tools 
+not only open, but **easy** to use, complete with an entire section dedicated to technical education.
+
+Here we explain our experience of building a scalable community website that can handle multiple different languages; 
+many different kinds of contributors; many different ways and means of contributing; why we've structured things as we have; how you 
+can extend anything; and how you can dive deeper into the internals of how specific modules and components work. You'll also learn how to 
+leverage our design system - [DAI-UI](https://github.com/makerdao/dai-ui) - to build slick, smooth and optimised user interfaces with minimal effort.
+
+It's great to speak the language of online community building, but one needs solid technical foundations on which to build truly transformative 
+ways of interacting and relating. This site is a building-block which sits on top of our open smart contracts that 
+define the actual protocols for a better kind of money, in order to show you how high the temple pillars can really reach.
+
+This is just the beginning of your journey. Once you've seen how easy it is to work with our technical community tools, and how they 
+interact with our Developer Experience and Design work, like DAI-UI, we hope you'll fall down the rabbit hole 
+and begin to figure out the deeper architectural challenges and intricacies of what "better money" might really mean for all of us.
+
+<Button to="https://docs.makerdao.com" primary>Protocol Documentation</Button>

--- a/content/en/develop/engineering/language.mdx
+++ b/content/en/develop/engineering/language.mdx
@@ -1,0 +1,10 @@
+---
+title: Languages
+order: 3
+---
+
+# Handling Languages
+
+Mostly intended for the LanguageSelector component, but perhaps also some other stuff? 
+
+Need to discuss if translations is a separate file entirely. I think it probably is...

--- a/content/en/develop/engineering/navigation.mdx
+++ b/content/en/develop/engineering/navigation.mdx
@@ -1,0 +1,8 @@
+---
+title: Navigation
+order: 1
+---
+
+# Navigation Automagic
+
+Sidebar and header description from PRs. Maybe a section for breadcrumb too, or maybe a separate file for that...

--- a/content/en/develop/engineering/search.mdx
+++ b/content/en/develop/engineering/search.mdx
@@ -1,0 +1,8 @@
+---
+title: Search
+order: 2
+---
+
+# The Intricacies of Searching Static Sites
+
+Description from Rejon Radio about Lunr's weirdness, like `AllMdx` to just `Mdx` etc.

--- a/content/en/develop/index.mdx
+++ b/content/en/develop/index.mdx
@@ -1,0 +1,20 @@
+---
+hideLanguageSelector: true
+---
+
+# Dai-log
+
+## Welcome to the conversation about how to create cohesive community
+
+This website is built so that anyone can **learn** from it, **use** it, **contribute content** to it, and **extend** it easily. 
+We want the people who write captivating ideas, and the people who code awesome tools, and the people who design our community brand 
+to be in a constant dialogue where ideas circulate smoothly and we all benefit from each other's unique skills.  
+
+This section therefore has two parts to it: 
+
+1. dialogic content guides to contributing the best content possible, leveraging the unique features of `mdx`  
+and the selection of powerful React components we have built for you. We'll take you from tentative comments in Google Docs to 
+coding your own React components in a few short weeks...
+2. an engineering log - or [colophon](https://en.wikipedia.org/wiki/Colophon_(publishing)) - explaining how we built the site so that you can understand its inner workings, help us 
+extend it and make it even more awesome, or use it as a boilerplate for your own project.
+


### PR DESCRIPTION
### Attention (CC)

cc @MaximumCrash
cc @twblack88  

## Summary of changes

An outline of the new `develop` section given what Rejon and I discussed last night and my own best guesses for some of the things. Split into 2 sections: `content` and `engineering` to cater for

1. Teaching content contributors how to level up their skillz and get dirty with React components.
2. Teaching engineers how the low level decisions in the site work, why we made them, and how they can use them in their own projects, or when extending this portal so that we can, for e.g. really use it to time travel.

## Motivation & Context

- Feature: Meta-documentation
- Issue: #49

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation Update
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added/changed necessary documentation (if appropriate)
- [ ] All new and existing tests passed.

## How Has This Been Tested?

Locally. It's just a first-pass to validate the structure with y'all and open the discussion. I will get to actual documentation once you look through this and edit/change/update any aspects of the architecture I'm suggesting. Few things I did notice:

1. The `hideLanguageSelector` frontmatter does not work as it is currently documented for me.
2. The `<CTA warning>` is likely the wrong colour...
