### PR TITLE
Fixed closed icon on Accordion

### DIFF
--- a/content/en/test.mdx
+++ b/content/en/test.mdx
@@ -1,56 +1,7 @@
-# Chocolate Box Component
+# Testing Accordion
 
+<Accordion openIcon="chevron_down" closeIcon="chevron_up">
 
-<Chocolate>
+Of course, it's also possible to have your own icons for opening and closing
 
-<Box>
-   
-<Icon name="eye" size={3}/>
-
-Measure community sentiment about issues affecting the MakerDAO ecosystem.
-
-[See example](https://example.com)
-
-</Box>
-
-<Box>
-   
-<Icon name="search" size={3}/>
-
-Determine the consensus that something needs to be done in response to a perceived issue.
-
-[See example](https://example.com)
-
-</Box>
-
-<Box>
-   
-<Icon name="search" size={3}/>
-
-Determine the consensus that something needs to be done in response to a perceived issue.
-
-[See example](https://example.com)
-
-</Box>
-
-<Box>
-   
-Determine the consensus that something needs to be done in response to a perceived issue.
-
-[See example](https://example.com)
-
-<Icon name="search" size={3}/>
-
-</Box>
-
-<Box>
-   
-<Icon name="search" size={3}/>
-
-Determine the consensus that something needs to be done in response to a perceived issue.
-
-[See example](https://example.com)
-
-</Box>
-
-</Chocolate>
+</Accordion>

--- a/src/modules/ui/Accordion.js
+++ b/src/modules/ui/Accordion.js
@@ -53,7 +53,14 @@ const Accordion = ({ children, defaultOpen, openIcon, closeIcon }) => {
               fontWeight: "bold",
             }}
           >
-            -
+          {/* TEMPORARY UNTIL MINUS ICON ADDED TO DAI-UI */}
+            {CloseIcon !== 'minus' ?
+              <Icon name={CloseIcon} color={"headline"} size={4}/>
+              :
+              <>
+              {"-"}
+              </> 
+            }
           </Box>
         )}
       </Flex>

--- a/src/modules/utility/LanguageSelector.js
+++ b/src/modules/utility/LanguageSelector.js
@@ -141,6 +141,7 @@ const LanguageSelector = () => {
         bg: "surface",
         position: "absolute",
         right: 0,
+        top: 0
       }}
     >
       <Text>{t("Available_Languages")}</Text>


### PR DESCRIPTION
<!-- If you're unsure about any question, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

### Attention (CC)
@andytudhope 
@twblack88 

## Summary of changes
Added logic fix for accordion close icons. 

## Motivation & Context
- Issue: #58 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation Update
- [ ] Other (please describe):

## Does this introduce a breaking change?

_Breaking change is defined as_ **"A fix or feature that would cause existing functionality to change."**

- [ ] Yes
- [x] No

<!--- If this introduces a breaking change, please describe the impact and migration path for existing modules below. -->

## Checklist:

<!--- Put an `x` in the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/changed necessary documentation (if appropriate)
- [ ] All new and existing tests passed.

## How Has This Been Tested?
Locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A

## Further comments

### About Icons

Our Icon pack is pulling from what the Dai-UI folks have put together ([see here](https://dai-ui.now.sh/icons). And until our designer wants to throw more icons into the pack we are currently limited to what they offer. (Without throwing in font-awesome icons **which has limited "free" tier and a large package**). 

The issue that this PR fixes is to support a custom close icon. However for the default Plus and Minus, the Minus is missing from the dai-ui icons. We can extend Dai-UI and add our own icons, but this requires tapping our designer for icons. (**As of this writing Shea is already talking to the Dai-ui team about extending it for her stylings**)

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
