### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     types: [assigned, opened, synchronize, reopened]
     
 jobs:
-  poolparty:
+  lifeguard:
     if: github.base_ref == 'r2d' || github.base_ref == 'master' || github.base_ref == 'production'
     runs-on: ubuntu-16.04
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-16.04
     
     steps:
-    - uses: actions/checkout@r2d
+    - uses: actions/checkout@v2
+      with:
+        ref: r2d
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,10 @@ name: PoolParty Deploy
 on:
   pull_request:
     types: [assigned, opened, synchronize, reopened]
-  release:
-    types: [published, created, edited]
     
 jobs:
-  test:
+  poolparty:
+    if: github.base_ref == 'r2d' || github.base_ref == 'master' || github.base_ref == 'production'
     runs-on: ubuntu-16.04
     
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-16.04
     
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@r2d
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1
       with:
@@ -29,6 +29,13 @@ jobs:
     - name: Making your code pretty. 
       run: | 
         yarn format
+        
+    - name: Label this PR with automerge
+      uses: TimonVS/pr-labeler-action@v3.1.0
+      with:
+        configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         
 


### PR DESCRIPTION
Related to: #200 

Updating the poolparty script to use the prlabeler prior. 

@twblack88 as we spook of before anyone who's forked this repo will have tests that **ALWAYS** fail because Github doesn't allow usage of the GITHUB_TOKEN for the pr-labeler when in the PR fork workflow. Only PRs that come from branches that have **cloned** this repo will pass their tests. (**People have complained about this for a long time, but Github is adamant that they will never change this for the sake of security. I agree.**) 

With that in mind that in mind, if folks don't want their tests to fail they **cannot** fork this repo. 

For example: 
![Screen Shot 2020-07-26 at 9 17 12 AM](https://user-images.githubusercontent.com/9157341/88479970-fbe1be00-cf20-11ea-8e68-24301a1fffbb.png)

Each time any of these people make a PR from their fork the test will fail. 

It would be better for folks to clone the repo like so: 

1. Click Code, open in GithubDesktop, your own gui, and copy the link. 
![Screen Shot 2020-07-26 at 9 19 20 AM](https://user-images.githubusercontent.com/9157341/88480010-482cfe00-cf21-11ea-8809-d1b04f173d4b.png)

2. If you're using your terminal go to a place where you want the folder to be created and type: `git clone https://github.com/makerdao/community-portal.git`

3. Enjoy and do your thing. 

