### PR TITLE
Design changes to topic pages for content, governance and risk, meetu…

### DIFF
--- a/content/en/work_with_us/bounties/index.mdx
+++ b/content/en/work_with_us/bounties/index.mdx
@@ -8,7 +8,19 @@ description: "Bounties are small to medium tasks that need help. They mostly cov
 
 # Bounties
 
-### Bounties are small to medium tasks that need help. They mostly cover work related to this site. You can earn Dai by completing bounties.
+<InfoBlock>
+
+![Bounties](/images/illustrations/Robot-1.png)
+
+<Box>
+
+## Bounties are small to medium tasks that need help. They mostly cover work related to this site. You can earn Dai by completing bounties.
+
+</Box>
+
+</InfoBlock>
+
+
 
 ## Requirements
 
@@ -72,7 +84,7 @@ We welcome all ideas to improve this site or the Maker community. Submit a propo
 
 ## Suggested Reading
 
-<Tout image alt>
+<Tout>
 
 <Box>
 

--- a/content/en/work_with_us/content/index.mdx
+++ b/content/en/work_with_us/content/index.mdx
@@ -7,11 +7,18 @@ description: "Community contributed content helps ensure up-to-date resources fo
 ---
 # Contributing Content
 
+<InfoBlock>
+
+![Content](/images/illustrations/Squid-4.png)
+
+<Box>
 
 ## Help us improve the community site by creating new content, editing existing content, or suggesting improvements. 
 
-Designers, Writers, Editors, and other skilled contributors are encouraged to help with current content creation efforts and propose new ones.
-Community contributed content helps ensure up-to-date resources for learning about MakerDAO, Maker, and Dai.
+</Box>
+
+</InfoBlock>
+
 
 <Callout secondary icon="dai">
 
@@ -21,6 +28,9 @@ Get paid in Dai to create content for Comm-Dev.
 
 
 ### Requirements
+
+Designers, Writers, Editors, and other skilled contributors are encouraged to help with current content creation efforts and propose new ones.
+Community contributed content helps ensure up-to-date resources for learning about MakerDAO, Maker, and Dai.
 
 Content contributors should be:
 

--- a/content/en/work_with_us/governance_and_risk_meetings/index.mdx
+++ b/content/en/work_with_us/governance_and_risk_meetings/index.mdx
@@ -8,132 +8,143 @@ description: "Weekly meetings allow a chance to participate in the community and
 
 # Governance and Risk Meetings
 
-### Discuss Ideas and Get Infomed
+<InfoBlock>
 
-<Image src="/images/placeholder.png" />
+![G&R Meetings](/images/placeholder.png)
 
-These meetings set the stage for cultural and operational consensus across the community for a broad range of stakeholders and issues related to these [frequent discussion topics](https://community-development.makerdao.com/governance/common-topics).
+<Box>
+
+## Discuss Ideas and Get Infomed
+
+</Box>
+
+</InfoBlock>
 
 ## When?
 
 Governance and risk meetings happen **every Thursday** at 4pm UTC.
 You are welcome to join!
 
-<Button to="https://calendar.google.com/calendar/embed?src=makerdao.com_3efhm2ghipksegl009ktniomdk@group.calendar.google.com&ctz=America/Los_Angeles">
-  Add to calendar
-</Button>
-
 <Button to="https://zoom.us/j/697074715"> 
   Join the call with voice/video
 </Button>
 
-<Callout icon>
+<Callout icon="warning">
 
-## Password Protection
-
-Public meetings are now password protected to prevent spam.
-
-The weekly password can be found [on the forums](https://forum.makerdao.com/c/governance/gnr)
+Public meetings are now password protected to prevent spam. The weekly password can be found [on the forums](https://forum.makerdao.com/c/governance/gnr)
 
 </Callout>
 
 ## What's On The Menu?
 
+
+These meetings set the stage for cultural and operational consensus across the community for a broad range of stakeholders and issues related to these [frequent discussion topics](https://community-development.makerdao.com/governance/common-topics).
+
 These calls are hosted by Governance Facilitators who puts together the agenda each week. Below are common inclusions:
 
-### Updates
+<Tout>
+<Box>
 
-<List>
+### Updates 
 
 - Weekly MIP Updates
-
 - Weekly Domain Team Updates
-
 - Working Group Updates As Needed
-
 - Collateral Onboarding Updates As Needed
 
-</List>
+</Box>
 
-### Procedural Matters
+<Box>
 
-<List>
+### Procedural Matters 
 
 - Monthly MIP Submission Reviews
-
 - Monthly Governance Cycle Reviews
-
 - Monthly Inclusion Poll Reviews
-
 - Monthly Governance Poll Reviews
 
-</List>
+</Box>
 
-### Presentations
+</Tout>
 
-<List>
+<Tout>
+
+<Box>
+
+### Presentations 
 
 - MIP and Subproposal Overviews
-
 - Technical Overviews
-
 - Working Group Project Overviews
-
 - Longer, More Detailed Team Updates
-
 - State of the Peg
-
 - Deep Dives into other [Frequent Topics](https://community-development.makerdao.com/governance/common-topics)
 
-</List>
+</Box>
+
+<Box>
 
 ### Discussion
 
-<List>
-
 - Comments and Questions are encouraged throughout the calls
-
 - MIP-focused discussion sessions
-
 - Other [Frequent Topic](https://community-development.makerdao.com/governance/common-topics) discussion sessions
-
 - Open-ended discussion sessions at the end of some calls
 
-</List>
 
-<Callout>
+</Box>
+</Tout>
 
-### Earn Dai by Taking Notes
+
+
+## Earn Dai by Taking Notes 
 
 Notes are an important way to document discussions and decisions, making the content more accessible to the people who can't join or who don't have the time to watch the recordings in full.
 
 <Link to="/notes/take-notes">Join our Summary Team and we’ll pay you.</Link>
 
-</Callout>
 
 ## Past Meeting Archives
 
 <List>
 
-- [Summaries]()
+<Link to="https://community-portal-staging.makerfoundation.com/en/">
 
-  - Read summaries of past meetings
+**Summaries**
 
-- [Frequent Topics]()
+Read summaries of past meetings
 
-  - See what's discussed in meetings
+</Link>
 
-- [Audio Recordings]()
+<Link to="https://community-development.makerdao.com/">
 
-  - Listen to past meetings
+**Frequent Topics**
 
-- [Video Recordings]()
+See what's discussed in meetings
 
-  - View past meetings
+</Link>
+
+<Link to="https://community-development.makerdao.com/">
+
+**Audio Recordings**
+
+Listen to past meetings
+
+</Link>
+
+<Link to="https://community-development.makerdao.com/">
+
+**Video Recordings**
+
+View past meetings
+
+</Link>
 
 </List>
 
-<Tout image alt>
+
+
+<Column> 
 
 <Box>
 
@@ -155,9 +166,9 @@ See where the voting happens and take a look at what’s being voted on right no
 
 </Box>
 
-</Tout>
+</Column>
 
-<Callout>
+<Callout icon="question_o">
 
 If you have any questions, feel free to reach out to us on <Link to={"https://chat.makerdao.com/channel/community-development"} icon={"rocketchat"}>Community Chat</Link>.
 

--- a/content/en/work_with_us/meetups/index.mdx
+++ b/content/en/work_with_us/meetups/index.mdx
@@ -8,7 +8,18 @@ description: "The front page for the meetup grants program."
 
 # Meetups
 
+<InfoBlock>
+
+![Meetups](/images/illustrations/Tall-3.png)
+
+<Box>
+
 ## Bringing together people to talk Maker, Dai or DeFi at a meetup is a fantastic way for you to help the community.
+
+</Box>
+
+</InfoBlock>
+
 
 <Callout icon="lightbulb">
 
@@ -102,8 +113,20 @@ Links to recordings of some great meetup presentations.
 
 </List>
 
+<Box sx={{ padding: 4 }}>
+
+<Column>
+
+<Box>
+
 ## Disclaimer
 
 These meetups are not for speculating on the price of the token or general hype. Events should focus on the MakerDao ecosystem, how MakerDao and Dai interact with DeFi, decentralized governance, and other relevant topics.
 
 The goal of hosting meetups is to bring people together and educate them about decentralized finance, Dai, and MakerDAO. When talking about the MKR token, the goal should be to educate the attendees about the purpose and utility of the token.
+
+</Box>
+
+</Column>
+
+</Box>


### PR DESCRIPTION
### Attention (CC) @twblack88 

<!--- Bring to the attention of others -->

## Summary of changes

Design changes to topic pages under Work With Us: Content, Governance and Risk, Meetups, Bounties
Restructured the Governance and Risk Page - it's still missing links - after this is merged, passing it off to Tom to make edits

@allcontributors please add @HaydenSander and @annaalexakr for design

